### PR TITLE
Feature: upgrade to Laravel 11 and drop PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        php: [8.2, 8.3]
+        laravel: [11]
 
     steps:
     - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- Minimum PHP version is now `8.2`.
+
 ## [3.0.0] - 2023-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased (Laravel 11)
+## Unreleased
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -43,11 +43,10 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev",
-            "dev-laravel11": "4.x-dev"
+            "dev-develop": "4.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel-json-api/core": "^3.0"
+        "php": "^8.2",
+        "laravel-json-api/core": "^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {
@@ -43,10 +43,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev"
+            "dev-develop": "3.x-dev",
+            "dev-laravel11": "4.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Changes needed to upgrade to Laravel 11, dropping PHP 8.1 at the same time.